### PR TITLE
removed making player x & y as ints.  It throws off the trig.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -413,8 +413,8 @@ function updatePlayerMotion(dt) {
   else
     var [px, py] = [player.x, player.y];
 
-  let tx = Math.trunc(Math.cos(player.r) * player.v * dt + px);
-  let ty = Math.trunc(Math.sin(player.r) * player.v * dt + py);
+  let tx = Math.cos(player.r) * player.v * dt + px;
+  let ty = Math.sin(player.r) * player.v * dt + py;
 
   // is the player even moving?
   if (px == tx && py == ty) {


### PR DESCRIPTION
this resolves issue #23 

A test that I did earlier persisted beyond its usefulness.  It turns out that forcing ```player.x```  and  ```player.y``` to be integers really throws off the trig.  