### PR TITLE
reverse sign on calculation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -426,8 +426,8 @@ function updatePlayerMotion(dt) {
   }
 
   //prevent overrun
-  dx = px - tx;
-  dy = py - ty;
+  dx = tx - px;
+  dy = ty - py;
   let largerDelta = Math.max(Math.abs(dx), Math.abs(dy));
   let dxStep = dx / largerDelta;
   let dyStep = dy / largerDelta;


### PR DESCRIPTION
the search along the path to ensure no overruns had the incorrect sign.  This seems to prevent path jumping much more effectively.  