### PR TITLE
Input refactoring to separate all input methods

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ gulp.task('self-watch', () => gulp.watch('gulpfile.js', process.exit));
 gulp.task('server', () => connect.server({
   root: 'dist',
   livereload: true,
-  host: '0.0.0.0',
+  host: 'localhost',
   port: '9000'
 }));
 

--- a/src/lib/input.js
+++ b/src/lib/input.js
@@ -5,6 +5,8 @@
   mouse: { x: 0, y: 0, down: false },
   touch: { active: false, x: 0, y: 0 },
 
+  lars_sez: '',
+
   init() {
     const windowEvents = {
       mousemove: this.handleMouseMove,
@@ -22,6 +24,8 @@
 
   handleKeyDown(ev) {
     this.keys[ev.keyCode] = true;
+    console.log(ev.keyCode);
+
     ev.preventDefault();
   },
 
@@ -104,6 +108,7 @@
     for (var i = 0; i < gamepads.length; i++) {
     	var gp = gamepads[i];
     	if (!gp || !gp.connected) continue;
+      //gp.buttons.forEach((val, idx) => val.pressed ? console.log(`button${idx}` + val.pressed.toString()) : '');
       gp.buttons.forEach((val, idx) => this.gamepad[`button${idx}`] = val.pressed);
       gp.axes.forEach((val, idx) => this.gamepad[`axis${idx}`] = val);
       break; // stop after the first gamepad

--- a/src/lib/input.js
+++ b/src/lib/input.js
@@ -2,7 +2,7 @@
   const Input = {
   keys: {  },
   gamepad: { },
-  mouse: { x: 0, y: 0, down: false },
+  mouse: { x: 0, y: 0, down: false, wheel: false },
   touch: { active: false, x: 0, y: 0 },
 
   lars_sez: '',
@@ -12,7 +12,8 @@
       mousemove: this.handleMouseMove,
       mousedown: this.handleMouseDown,
       mouseup: this.handleMouseUp,
-      //wheel: this.handleWheel,
+      contextmenu: this.ignoreThisEvent,
+      wheel: this.handleWheel,
       keydown: this.handleKeyDown,
       keyup: this.handleKeyUp,
       touchstart: this.handleTouchStart,
@@ -25,7 +26,6 @@
 
   handleKeyDown(ev) {
     this.keys[ev.keyCode] = true;
-    console.log(ev.keyCode.toString());
     ev.preventDefault();
   },
 
@@ -45,7 +45,7 @@
   },
 
   handleMouseDown(ev) {
-    this.mouse.down = true;
+    this.mouse.down = ev.button;
     ev.preventDefault();
   },
 
@@ -54,6 +54,14 @@
     ev.preventDefault();
   },
 
+  ignoreThisEvent(ev) {
+    ev.preventDefault();
+  },
+
+  handleWheel(ev) {
+    this.mouse.wheel = ev.deltaY;
+    ev.preventDefault();
+  },
 
   touchEventTracker: { },
 
@@ -108,7 +116,6 @@
     for (var i = 0; i < gamepads.length; i++) {
     	var gp = gamepads[i];
     	if (!gp || !gp.connected) continue;
-      //gp.buttons.forEach((val, idx) => val.pressed ? console.log(`button${idx}` + val.pressed.toString()) : '');
       gp.buttons.forEach((val, idx) => this.gamepad[`button${idx}`] = val.pressed);
       gp.axes.forEach((val, idx) => this.gamepad[`axis${idx}`] = val);
       break; // stop after the first gamepad

--- a/src/lib/input.js
+++ b/src/lib/input.js
@@ -12,6 +12,7 @@
       mousemove: this.handleMouseMove,
       mousedown: this.handleMouseDown,
       mouseup: this.handleMouseUp,
+      //wheel: this.handleWheel,
       keydown: this.handleKeyDown,
       keyup: this.handleKeyUp,
       touchstart: this.handleTouchStart,
@@ -24,8 +25,7 @@
 
   handleKeyDown(ev) {
     this.keys[ev.keyCode] = true;
-    console.log(ev.keyCode);
-
+    console.log(ev.keyCode.toString());
     ev.preventDefault();
   },
 

--- a/src/lib/input.js
+++ b/src/lib/input.js
@@ -1,5 +1,6 @@
-const Input = {
-  keys: { },
+
+  const Input = {
+  keys: {  },
   gamepad: { },
   mouse: { x: 0, y: 0, down: false },
   touch: { active: false, x: 0, y: 0 },
@@ -19,6 +20,16 @@ const Input = {
       .forEach(k => window.addEventListener(k, windowEvents[k].bind(this)));
   },
 
+  handleKeyDown(ev) {
+    this.keys[ev.keyCode] = true;
+    ev.preventDefault();
+  },
+
+  handleKeyUp(ev) {
+    delete this.keys[ev.keyCode];
+    ev.preventDefault();
+  },
+
   update(dt) {
     this.updateGamepads(dt);
   },
@@ -26,28 +37,6 @@ const Input = {
   handleMouseMove(ev) {
     this.mouse.x = ev.clientX;
     this.mouse.y = ev.clientY;
-    ev.preventDefault();
-  },
-
-  handleTouchStart(ev) {
-    this.touch.active = true;
-    if (ev.changedTouches.length > 0) {
-      this.touch.x = ev.changedTouches[0].pageX;
-      this.touch.y = ev.changedTouches[0].pageY;
-    }
-    ev.preventDefault();
-  },
-
-  handleTouchMove(ev) {
-    if (ev.changedTouches.length > 0) {
-      this.touch.x = ev.changedTouches[0].pageX;
-      this.touch.y = ev.changedTouches[0].pageY;
-    }
-    ev.preventDefault();
-  },
-
-  handleTouchEnd(ev) {
-    this.touch.active = false;
     ev.preventDefault();
   },
 
@@ -61,13 +50,50 @@ const Input = {
     ev.preventDefault();
   },
 
-  handleKeyDown(ev) {
-    this.keys[ev.keyCode] = true;
+
+  touchEventTracker: { },
+
+  startTrackTouch(touch) {
+    let id = "t" + touch.identifier.toString();
+    this.touchEventTracker[id] = {
+      timestamp: Date.now(),
+      x: touch.pageX,
+      y: touch.pageY,
+      xStart: touch.pageX,
+      yStart: touch.pageY,
+      ended: false
+    }
+  },
+
+  trackTouch(touch) {
+    let id = "t" + touch.identifier.toString();
+    this.touchEventTracker[id].x = touch.pageX;
+    this.touchEventTracker[id].y = touch.pageY;
+  },
+
+  endTrackTouch(touch) {
+    let id = "t" + touch.identifier.toString();
+    this.touchEventTracker[id].ended = true;
+  },
+
+
+  handleTouchStart(ev) {
+    this.touch.active = true;
+    for (let i = 0; i < ev.changedTouches.length; i++)
+      this.startTrackTouch(ev.changedTouches[i]);
     ev.preventDefault();
   },
 
-  handleKeyUp(ev) {
-    delete this.keys[ev.keyCode];
+  handleTouchMove(ev) {
+    for (let i = 0; i < ev.changedTouches.length; i++)
+      this.trackTouch(ev.changedTouches[i]);
+    ev.preventDefault();
+  },
+
+  handleTouchEnd(ev) {
+    this.touch.active = false;
+    for (let i = 0; i < ev.changedTouches.length; i++)
+      this.endTrackTouch(ev.changedTouches[i]);
     ev.preventDefault();
   },
 


### PR DESCRIPTION
built on top of the existing ```Input``` system to create higher level command creation.  Each method of input now has a separate section to gather commands - this simplifies and isolates the messy ways that the devices differ in how they need to create commands.  I've also included a section to gather input from orientation and shaking.  Though it is currently unimplemented.

With this, several new commands have been implemented:

AUTO-ZOOM - has been turned off by default.  This is because I noticed that people using a touch interface kept trying to use pinch to zoom to get the zoom level where they wanted it and didn't like the continually confusing zoom in / zoom out.   Auto zoom can now be toggled using:  keyboard - z key; touch - three finger tap; game controller - button3 (yellow button on my controller); mouse - middle button

BACKUP - breadcrumbs now only happen automatically.  the player can jump back to the last breadcrumb with:  keyboard - backspace; touch - 2 finger tap; game controller - button2 or button6; mouse - right button (context menu disabled)

ZOOM - when auto-zoom is off, the player can select their own zoom level.  keyboard: +/= zoom in, - zoom out; mouse - scroll wheel; touch - pinch; game controller - button0 (green) zoom in, button1 (red) zoom out.

The infrastructure for SAVE & QUIT now exist, but they are unimplemented.  

for local use, I've changed the ip "0.0.0.0" to "localhost" so it becomes available to all devices on my network.
