### PR TITLE
stopped a page reload race condition by adding done state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -793,10 +793,16 @@ const endAnimation = {
   },
 
   reset(dt) {
+    this.animationState = done;
     document.location.reload(true);
   },
   reset_draw(dt) {
   },
+
+  done(dt) {
+  },
+  done_draw(dt){
+  }
 }
 
 const cheatAnimation = {


### PR DESCRIPTION
suddenly the reload at the end has started looping  - not sure why this hasn't appeared before.  Resolved it by ensuring that the ```...location.reload``` happens only once in the end animation.